### PR TITLE
Simpler usage. Eliminated extra Swift build parameter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 
 let package = Package(
 	name: "OpenSSL",
-	pkgConfig: "openssl",
+	pkgConfig: "open-ssl",
 	providers: [
 		.Brew("openssl"), 
 	]

--- a/open-ssl.pc
+++ b/open-ssl.pc
@@ -1,0 +1,9 @@
+prefix=/usr/local/opt/openssl/
+includedir=${prefix}/include/
+libdir=${prefix}/lib
+
+Name: open-ssl
+Description: Open SSL library
+Version: 1.0.2
+Cflags: -F${includedir} -I${includedir}
+Libs: -L${libdir} -lssl -lcrypto

--- a/shim.h
+++ b/shim.h
@@ -14,8 +14,14 @@
  * limitations under the License.
  **/
  
-module OpenSSL [system] {
-       header "shim.h"
-       link "ssl"
-       link "crypto"
-} 
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+#include <openssl/md4.h>
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+


### PR DESCRIPTION
Eliminated the need to add -Xcc -I/usr/local/opt/openssl/include to the swift build command when using this as a dependency.

I added a "local" .pc file and a shim.h that better specify the needed compiler parameters.
