### PR TITLE
Fix build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 /**
-* Copyright IBM Corporation 2016
+* Copyright IBM Corporation 2016, 2017
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import PackageDescription
 
 let package = Package(
 	name: "OpenSSL",
-	pkgConfig: "open-ssl",
+	pkgConfig: "openssl",
 	providers: [
 		.Brew("openssl"), 
 	]

--- a/open-ssl.pc
+++ b/open-ssl.pc
@@ -1,9 +1,0 @@
-prefix=/usr/local/opt/openssl/
-includedir=${prefix}/include/
-libdir=${prefix}/lib
-
-Name: open-ssl
-Description: Open SSL library
-Version: 1.0.2
-Cflags: -F${includedir} -I${includedir}
-Libs: -L${libdir} -lssl -lcrypto


### PR DESCRIPTION
At the moment, the build fails, and open-ssl.pc is not checked.
The proposed changes: update pgconfig in Package.swift to be "openssl", remove open-ssl.pc.