### PR TITLE
Add openssl to pkgConfig

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -21,6 +21,7 @@ import PackageDescription
 
 let package = Package(
     name: "OpenSSL",
+    pkgConfig: "openssl",
     providers: [
         .brew(["openssl"])
     ],


### PR DESCRIPTION
In a past [commit](https://github.com/IBM-Swift/OpenSSL-OSX/commit/3e0608f841aadfa027fbf7790cad871d1e694174) a pkgConfig was added to the package.swift to remove the need for linker flags. This has not been added to the Package@swift-4.swift meaning that if you use this for swift 4 you need to use linker flags.
This PR adds pkgConfig: "openssl" so that projects which depend on this do not need to specify flags.
If people do specify flags as before then the project will still build.