### PR TITLE
Fix: remove target of OpenSSL

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -31,8 +31,5 @@ let package = Package(
             name: "OpenSSL",
             targets: ["OpenSSL"]
         )
-    ],
-    targets: [
-        .target(name: "OpenSSL")
     ]
 )


### PR DESCRIPTION
In the package.swift file we target OpenSSL. 
When you use this module this causes the following warning:

"warning: Ignoring declared target(s) 'OpenSSL' in the system package"

This PR remove this unnecessary target to remove the warning message 